### PR TITLE
adding Bing Image Search ruby and c# quickstart samples

### DIFF
--- a/dotnet/Search/BingImageSearchv7Quickstart.cs
+++ b/dotnet/Search/BingImageSearchv7Quickstart.cs
@@ -1,0 +1,83 @@
+//Copyright (c) Microsoft Corporation. All rights reserved.
+//Licensed under the MIT License.
+
+using System;
+using System.Net;
+using System.IO;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace BingSearchApisQuickstart
+{
+
+    class Program
+    {
+
+        // Replace this string value with your valid access key.
+        const string subscriptionKey = "bbfb78ad189649248750011e83b7b22d";
+
+        // Verify the endpoint URI. If you encounter unexpected authorization errors,
+        // double-check this value against the Bing search endpoint in your Azure dashboard.
+        const string uriBase = "https://api.cognitive.microsoft.com/bing/v7.0/images/search";
+
+        const string searchTerm = "tropical ocean";
+
+        // A struct to return image search results seperately from headers
+        struct SearchResult
+        {
+            public string  jsonResult;
+            public Dictionary<String, String> relevantHeaders;
+        }
+
+        static void Main()
+        {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+
+            Console.WriteLine("Searching images for: " + searchTerm + "\n");
+            //send a search request using the search term
+            SearchResult result = BingImageSearch(searchTerm);
+            //deserialize the JSON response from the Bing Image Search API
+            dynamic jsonObj = Newtonsoft.Json.JsonConvert.DeserializeObject(result.jsonResult);
+
+            var firstJsonObj = jsonObj["value"][0];
+            Console.WriteLine("Title for the first image result: " + firstJsonObj["name"]+"\n");
+            //After running the application, copy the output URL into a browser to see the image. 
+            Console.WriteLine("URL for the first image result: " + firstJsonObj["webSearchUrl"]+"\n");
+
+            Console.Write("\nPress Enter to exit ");
+            Console.ReadLine();
+        }
+
+        /// <summary>
+        /// Performs a Bing Image search and return the results as a SearchResult.
+        /// </summary>
+        static SearchResult BingImageSearch(string searchQuery)
+        {
+            // Construct the URI of the search request
+            var uriQuery = uriBase + "?q=" + Uri.EscapeDataString(searchQuery);
+
+            // Perform the Web request and get the response
+            WebRequest request = WebRequest.Create(uriQuery);
+            request.Headers["Ocp-Apim-Subscription-Key"] = subscriptionKey;
+            HttpWebResponse response = (HttpWebResponse)request.GetResponseAsync().Result;
+            string json = new StreamReader(response.GetResponseStream()).ReadToEnd();
+
+            // Create result object for return
+            var searchResult = new SearchResult()
+            {
+                jsonResult = json,
+                relevantHeaders = new Dictionary<String, String>()
+            };
+
+            // Extract Bing HTTP headers
+            foreach (String header in response.Headers)
+            {
+                if (header.StartsWith("BingAPIs-") || header.StartsWith("X-MSEdge-"))
+                    searchResult.relevantHeaders[header] = response.Headers[header];
+            }
+
+            return searchResult;
+        }
+
+    }
+}

--- a/dotnet/Search/BingImageSearchv7Quickstart.cs
+++ b/dotnet/Search/BingImageSearchv7Quickstart.cs
@@ -14,7 +14,7 @@ namespace BingSearchApisQuickstart
     {
 
         // Replace this string value with your valid access key.
-        const string subscriptionKey = "bbfb78ad189649248750011e83b7b22d";
+        const string subscriptionKey = "Enter your subscription key here";
 
         // Verify the endpoint URI. If you encounter unexpected authorization errors,
         // double-check this value against the Bing search endpoint in your Azure dashboard.

--- a/ruby/Search/BingImageSearchv7.rb
+++ b/ruby/Search/BingImageSearchv7.rb
@@ -1,0 +1,49 @@
+ruby
+require 'net/https'
+require 'uri'
+require 'json'
+
+# **********************************************
+# *** Update or verify the following values. ***
+# **********************************************
+
+# Replace the accessKey string value with your valid access key.
+accessKey = "enter key here"
+
+# Verify the endpoint URI.  At this writing, only one endpoint is used for Bing
+# search APIs.  In the future, regional endpoints may be available.  If you
+# encounter unexpected authorization errors, double-check this value against
+# the endpoint for your Bing Search instance in your Azure dashboard.
+
+uri  = "https://api.cognitive.microsoft.com"
+path = "/bing/v7.0/images/search"
+
+term = "puppies"
+
+if accessKey.length != 32 then
+    puts "Invalid Bing Search API subscription key!"
+    puts "Please paste yours into the source code."
+    abort
+end
+
+uri = URI(uri + path + "?q=" + URI.escape(term))
+
+puts "Searching images for: " + term
+
+request = Net::HTTP::Get.new(uri)
+request['Ocp-Apim-Subscription-Key'] = accessKey
+
+response = Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
+    http.request(request)
+end
+
+puts "\nRelevant Headers:\n\n"
+response.each_header do |key, value|
+    # header names are coerced to lowercase
+    if key.start_with?("bingapis-") or key.start_with?("x-msedge-") then
+        puts key + ": " + value
+    end
+end
+
+puts "\nJSON Response:\n\n"
+puts JSON::pretty_generate(JSON(response.body))


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

This code sample exists on docs.microsoft.com, but not on Github. I'm adding it here.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [https://github.com/aahill/cognitive-services-REST-api-samples.git]
cd [cognitive-services-REST-api-samples/ruby/Search]
git checkout [ image-search-ruby-add ]
run BingImageSearchv7.rb
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...
The code sample runs and displays a JSON response from the Bing Image Search API.

## Other Information
<!-- Add any other helpful information that may be needed here. -->