### PR TITLE
Updated key/endpoint

### DIFF
--- a/java/Search/BingAutosuggestv7.java
+++ b/java/Search/BingAutosuggestv7.java
@@ -27,14 +27,14 @@ import com.google.gson.JsonParser;
 
 public class Autosuggest {
 
-// **********************************************
-// *** Update or verify the following values. ***
-// **********************************************
+    // **********************************************
+    // *** Update or verify the following values. ***
+    // **********************************************
 
-// Replace the subscriptionKey string value with your valid subscription key.
-    static String subscriptionKey = "enter key here";
+    // Add your Bing Autosuggest subscription key to your environment variables.
+    static String subscriptionKey = System.getenv("BING_AUTOSUGGEST_SUBSCRIPTION_KEY");
 
-    static String host = "https://api.cognitive.microsoft.com";
+    static String host = System.getenv("BING_AUTOSUGGEST_ENDPOINT");
     static String path = "/bing/v7.0/Suggestions";
 
     static String mkt = "en-US";


### PR DESCRIPTION
Endpoints are not region-based anymore, but rather custom domain -based. Although regional endpoints will still work. Also, the authentication information is moving to a standard of getting it from environment variables.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```